### PR TITLE
[WIP] update/grammar_syntax

### DIFF
--- a/docs/en/how-to_guides/ThanoSQL_query/BUILD_SYNTAX.md
+++ b/docs/en/how-to_guides/ThanoSQL_query/BUILD_SYNTAX.md
@@ -1,19 +1,19 @@
 ---
-title: BUILD MODEL 
+title: BUILD  
 ---
 
-# __BUILD MODEL__
+# __BUILD__
 
-## __1. BUILD MODEL Statement__
+## __1. BUILD Statement__
 
-The "__BUILD MODEL__" statement enables users to create a desired AI model without any expertise in data science. 
+The "__BUILD__" statement enables users to create a desired AI model without any expertise in data science. 
 
-## __2. BUILD MODEL Syntax__
+## __2. BUILD Syntax__
 
 ```sql
 %%thanosql
-BUILD MODEL [custom_model_name]
-USING [AI_model_to_use]
+BUILD [custom_model_name]
+USING CLASS [AI_model_class_to_use]
 OPTIONS ([option_values_​​required_when_creating_an_AI_model])
 AS
 [dataset_to_use]
@@ -24,7 +24,7 @@ AS
     - The "__OPTIONS__" clause can change the value of a parameter. The meaning of each parameter is as follows:
         - "overwrite" : Overwrite if a model with the same name exists. If True, the existing model is overwritten with the new model. (DEFAULT: False)
 
-## __3. BUILD MODEL Example__
+## __3. BUILD Example__
 
 !!! note
     - Examples are specific to one model, and the required option values ​​or the dataset used may differ from model to model. For a detailed description of each model, refer to [ThanoSQL Pre-built Model Statement Reference](/en/how-to_guides/reference/#thanosql-pre-built-model-statement-reference)
@@ -34,8 +34,8 @@ AS
 
 ```sql
 %%thanosql
-BUILD MODEL mymodel
-USING AutomlClassifier
+BUILD mymodel
+USING CLASS AutomlClassifier
 OPTIONS (
     target='survived',
     impute_type='iterative',
@@ -47,7 +47,7 @@ SELECT *
 FROM titanic_train
 ```
 
-!!! note "AI models that can be used with '__BUILD MODEL__ statement'"
+!!! note "AI models that can be used with '__BUILD__ statement'"
     - Auto-ML Classification model - AutomlClassifier
     - Auto-ML Regression model - AutomlRegressor
     - ConvNeXT Model - ConvNeXt_Tiny, ConvNeXt_Base


### PR DESCRIPTION
# Description (개요)

thanosql-engine repo 에서 이번 [PR](https://github.com/smartmind-team/thanosql-engine/pull/155)로 인해서 grammar가 전반적으로 수정 되었습니다. 그것에 따른 thanosql-docs rep의 변경 사항을 체계적으로 정리하고 수정하기 위해서 이 PR을 만들었습니다. 

@yeemh tutorial도 수정 되어야 하는 부분이 있습니다. `SEARCH`는 아직 finalized 안된 관계로 제일 마지막에 고치면 될거 같습니다. 

## Type of change (작업사항)

Grammar 수정으로 인한 docs 수정 

- [x] Docs Update 

## Changed Logic (변경 로직)

변경 되어야 하는 Grammar:

### Before (변경 전)

```antlr
BUILD MODEL - USING - AS 
FIT MODEL - USING - AS 
TRANSFORM  - USING - AS 
PREDICT - USING - AS 
EVALUATE - USING - AS 
PREPROCESS IMAGE/AUDIO/VIDEO/TEXT - USING - FROM
SEARCH IMAGE/AUDIO/VIDEO/KEYWORD/TEXT - USING - AS
```

### After (변경 후)

```antlr
BUILD - USING CLASS - AS 
FIT - USING MODEL - AS 
TRANSFORM  - USING MODEL - AS 
PREDICT - USING MODEL - AS 
EVALUATE - USING MODEL - AS 
PREPROCESS IMAGE/AUDIO/VIDEO/TEXT - USING METHOD - FROM
SEARCH IMAGE/AUDIO/VIDEO/KEYWORD/TEXT - USING  MODEL - AS
```

# Checklist:

- [ ] BUILD syntax - Ko 
- [ ] BUILD syntax - En 
- [ ] FIT syntax - Ko
- [ ] FIT syntax - En
- [ ] TRANSFORM syntax - Ko
- [ ] TRANSFORM syntax - En
- [ ] PREDICT syntax - Ko 
- [ ] PREDICT syntax - EN 
- [ ] EVALUATE syntax - Ko
- [ ] EVALUATE syntax - En
- [ ] PREPROCESS - Ko
- [ ] PREPROCESS - En
- [ ] SEARCH - Ko
- [ ] SEARCH - En 
- [ ] Using 관한 docs 작성 - Ko
- [ ] Using 관한 docs 작성 - En
- [ ] .pages - Ko
- [ ] .pages - En
- [ ] mkdocs.yaml