### PR TITLE
changed hyper-links for mnist dataset

### DIFF
--- a/archive/tutorials_en/thanosql_search/image_search/simclr_image_search.md
+++ b/archive/tutorials_en/thanosql_search/image_search/simclr_image_search.md
@@ -10,7 +10,7 @@ title: Search image by image
 - 7 min read
 - Languages : [SQL](https://ko.wikipedia.org/wiki/SQL) (100%)
 - File location : tutorial/tutorial_en/query/search_image_by_image_en.ipynb
-- References : [MNIST Data Set](http://yann.lecun.com/exdb/mnist/), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
+- References : [Introduction of MNIST Data Set](https://en.wikipedia.org/wiki/MNIST_database), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
 - Updated Date : {{ git_revision_date_localized }}
 
 ## Tutorial Introduction

--- a/archive/tutorials_ko/thanosql_search/image_search/simclr_image_search.md
+++ b/archive/tutorials_ko/thanosql_search/image_search/simclr_image_search.md
@@ -10,7 +10,7 @@ title: 이미지로 이미지 검색하기
 - 읽는데 걸리는 시간 : 7분
 - 사용 언어 : [SQL](https://ko.wikipedia.org/wiki/SQL) (100%)
 - 실행 파일 위치 : tutorial/query/이미지로 이미지 검색하기.ipynb   
-- 참고 문서 : [MNIST 데이터 세트](http://yann.lecun.com/exdb/mnist/), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
+- 참고 문서 : [MNIST 데이터 세트 소개](https://en.wikipedia.org/wiki/MNIST_database), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
 - 마지막 수정날짜 : {{ git_revision_date_localized }}
 
 ## 튜토리얼 소개

--- a/archive/tutorials_ko/thanosql_search/search_image_by_image.ipynb
+++ b/archive/tutorials_ko/thanosql_search/search_image_by_image.ipynb
@@ -19,7 +19,7 @@
     "- 읽는데 걸리는 시간 : 7분\n",
     "- 사용 언어 : [SQL](https://ko.wikipedia.org/wiki/SQL) (100%)\n",
     "- 실행 파일 위치 : tutorial/thanosql_search/search_image_by_image.ipynb   \n",
-    "- 참고 문서 : [MNIST 데이터 세트](http://yann.lecun.com/exdb/mnist/), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)"
+    "- 참고 문서 : [MNIST 데이터 세트 소개](https://en.wikipedia.org/wiki/MNIST_database), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)"
    ]
   },
   {

--- a/docs/en/tutorials/thanosql_search/search_image_by_image.md
+++ b/docs/en/tutorials/thanosql_search/search_image_by_image.md
@@ -8,7 +8,7 @@ title: Search Image by Image
 - 7 min read
 - Languages : [SQL](https://en.wikipedia.org/wiki/SQL) (100%)
 - File location : tutorial_en/thanosql_search/search_image_by_image.ipynb
-- References : [MNIST DataSet](http://yann.lecun.com/exdb/mnist/), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
+- References : [Introduction of MNIST DataSet](https://en.wikipedia.org/wiki/MNIST_database), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
 
 ## Tutorial Introduction
 

--- a/docs/ko/tutorials/thanosql_search/search_image_by_image.md
+++ b/docs/ko/tutorials/thanosql_search/search_image_by_image.md
@@ -8,7 +8,7 @@ title: 이미지로 이미지 검색하기
 - 읽는데 걸리는 시간 : 7분
 - 사용 언어 : [SQL](https://ko.wikipedia.org/wiki/SQL) (100%)
 - 실행 파일 위치 : tutorial/thanosql_search/search_image_by_image.ipynb   
-- 참고 문서 : [MNIST 데이터 세트](http://yann.lecun.com/exdb/mnist/), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
+- 참고 문서 : [MNIST 데이터 세트 소개](https://en.wikipedia.org/wiki/MNIST_database), [A Simple Framework for Contrastive Learning of Visual Representations](https://arxiv.org/abs/2002.05709)
 
 ## 튜토리얼 소개
 


### PR DESCRIPTION
오피셜 mnist site가 문을 닫았기에 타 사이트를 통한 데이터 다운로드 링크 보다는 위키피디아의 소개가 나을 것 같아 위키피디아 소개 링크로 대체 하였습니다. 
수정한 파일은 다음과 같습니다.

1. 이미지로 이미지 검색하기 (SimCLR) 기술문서 (한글)
2. 이미지로 이미지 검색하기 (SimCLR) 기술문서 (영문)
3. Archived/이미지로 이미지 검색하기 (SimCLR) 기술문서 (한글)
4. Archived/이미지로 이미지 검색하기 (SimCLR) 기술문서 (영문)
5. Archived/이미지로 이미지 검색하기 (SimCLR) 튜토리얼 ipynb 파일(한글)

![image](https://user-images.githubusercontent.com/55899856/203911811-4ec30dfe-8ee1-45f7-afb2-b2bc689c1081.png)


이미지로 이미지 검색하기 (SimCLR) 기술문서 (한/영) - 