### PR TITLE
Update: Reuse mkdocs-jupyter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: yeemh/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # EXTRA_PACKAGES: "build-base libxml2-dev libxslt-dev" # Needs when mkdocs-jupyter using

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ theme:
 
 plugins:
   - search # Built-in search plugin
+  - mkdocs-jupyter: # Currently not using. If going to use, run pipenv install mkdocs-jupyter
+      include_source: True # Enable download ipynb files
   # Multiple language versions
   - i18n:
       default_language: en
@@ -60,8 +62,6 @@ plugins:
   # Adding the date of last update
   - git-revision-date-localized:
       type: iso_date # Format yyyy-mm-dd
-  # - mkdocs-jupyter: # Currently not using. If going to use, run pipenv install mkdocs-jupyter
-  #     include_source: True # Enable download ipynb files
 
 # Extensions
 markdown_extensions:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -13,5 +13,8 @@
     .jupyter-wrapper a {
         color: var(--md-typeset-a-color)
     }
+    .jupyter-wrapper table.dataframe {
+        table-layout: auto;
+    }
 </style>
 {% endblock content %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 mkdocs-awesome-pages-plugin==2.8.0
 mkdocs-git-revision-date-localized-plugin==1.1.0
 mkdocs-material==8.5.2
-mkdocs-static-i18n==0.47
+git+https://github.com/yeemh/mkdocs-static-i18n.git@feat/jupyter
+mkdocs-jupyter==0.21.0
 mkdocs==1.3.1
 pymdown-extensions==9.5


### PR DESCRIPTION
# Description (개요) 

tutorial에서 한 작업을 수동으로 docs에 업로드 하던 것을 자동화 하기 위해 mkdocs-jupyter를 재사용합니다.

- github actions에서 오래된 버전을 업데이트 했습니다.
- github actions에서 pip를 업데이트 해주기 위해 fork 하여 사용하도록 변경했습니다.
- revision-date 플러그인을 위해 fetch-depth를 추가했습니다.
- mkdocs-static-i18n과 mkdocs-jupyter가 호환될 수 있도록 mkdocs-static-18n을 fork 후 수정하여 해당 레포의 브랜치를 사용하도록 했습니다.
- Safari에서 데이터프레임이 겹쳐 보이던 문제를 해결했습니다.

## Keep in Mind

If you are creating a new statement, your first commit should always be a copy of the statement(model, ThanoSQL, function) template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

Please delete options that are not relevant and check out the type of change.

- [x] MKdocs update

## Review Process

Review should be conducted by at least two people.