### PR TITLE
update: chunksize added as an option for COPY syntax

### DIFF
--- a/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -17,13 +17,16 @@ The "__COPY__" statement allows users to create data tables in the ThanoSQL work
 
 ```sql
 COPY (table_name_expression)
-OPTIONS (overwrite=True)
+OPTIONS (
+    expression [ , ...]
+    )
 FROM (file_path | dir_path)
 ```
 
 !!! note "__Query Details__"
     - The "__OPTIONS__" clause allows you to change the value of a parameter. The definition of each parameter is as follows.
         - "overwrite": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)
+        - "chunksize": the number of rows in each batch to be written at a time. By default, all rows will be written at once (int, optonal, default: 1000)
 
 ## __3. COPY Example__
 

--- a/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -17,13 +17,16 @@ title: COPY
 
 ```sql
 COPY (table_name_expression)
-OPTIONS (overwrite=True)
+OPTIONS (
+    expression [ , ...]
+    )
 FROM (file_path | dir_path)
 ```
 
 !!! note "쿼리 세부 정보"
     - "__OPTIONS__" 절에서 매개변수의 값을 기본값으로부터 변경할 수 있습니다. 각 매개변수의 의미는 아래와 같습니다.
         - "overwrite": 동일 이름의 테이블이 존재하는 경우 덮어쓰기 가능 여부를 설정합니다. True일 경우 기존 테이블은 새로운 테이블로 변경됩니다. (bool, optional, True|False, default: False)
+        - "chunksize": 한 번에 쓸 각 배치의 행 수입니다. 기본적으로 모든 행이 한 번에 기록됩니다 (int, optional, default: 1000)
 
 ## __3. COPY 예시__
 


### PR DESCRIPTION
# Description (개요) 

ThanoSQL Engine repo의 이번 [PR](https://github.com/smartmind-team/thanosql-engine/pull/187)로 COPY 구문에 "chunksize" option이 생겼습니다. 새로운 option을 설명하기 위해서 COPY syntax 업데이트 하였습니다. 

## Keep in Mind

If you are creating a new statement, your first commit should always be a copy of the statement(model, ThanoSQL, function) template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

- [x] ThanoSQL statement fix 

Following templates can be found from the [Tech-wiki Docs](https://github.com/smartmind-team/tech-wiki/tree/main/project/thanosql/docs). 

## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.