### PR TITLE
update: parquet and pqt added as supported file type for COPY clause

### DIFF
--- a/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -12,6 +12,7 @@ The "__COPY__" statement allows users to create data tables in the ThanoSQL work
     - csv
     - pkl, pickle
     - xls, xlsx, xlsm, xlsb
+    - pqt, parquet 
 
 ## __2. COPY Syntax__
 

--- a/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -12,6 +12,7 @@ title: COPY
     - csv
     - pkl, pickle
     - xls, xlsx, xlsm, xlsb
+    - pqt, parquet 
 
 ## __2. COPY 구문__
 


### PR DESCRIPTION
# Description (개요) 

Engine에서 COPY clause에 parquet file type을 새로 도입 했습니다. [Engine PR](https://github.com/smartmind-team/thanosql-engine/pull/193) 그에 따른 보충 설명을 추가하는 PR 입니다. 

## Keep in Mind

If you are creating a new statement, your first commit should always be a copy of the statement(model, ThanoSQL, function) template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

Please delete options that are not relevant and check out the type of change.

- [x] ThanoSQL statement fix 

Following templates can be found from the [Tech-wiki Docs](https://github.com/smartmind-team/tech-wiki/tree/main/project/thanosql/docs). 

## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.