### PR TITLE
update: 'overwrite' replaced by 'if_exists'

### DIFF
--- a/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -26,7 +26,10 @@ FROM {file_path | dir_path}
 
 !!! note "__Query Details__"
     - The "__OPTIONS__" clause allows you to change the value of a parameter. The definition of each parameter is as follows.
-        - "overwrite": determines whether to overwrite a table if it already exists. If set as True, the old table is replaced with the new table (bool, optional, True|False, default: False)
+        - "if_exists": determines how the function should handle the case where the table already exists, it can either raise an error, append to the existing table, or replace the existing table (str, optional, 'fail'|'replace'|'append', default: 'fail')
+            - "fail": raise an error if there is already an existing table
+            - "replace": replace a table if there is already an existing table
+            - "append": append given dataframe to an existing table
         - "chunksize": the number of rows in each batch to be written at a time. By default, all rows will be written at once (int, optonal, default: 1000)
 
 ## __3. COPY Example__
@@ -38,7 +41,7 @@ The example below demonstrates how to use a data file for the "__COPY__" clause.
 ```sql
 %%thanosql
 COPY mytable
-OPTIONS (overwrite=True)
+OPTIONS (if_exists='replace')
 FROM 'data/example.csv'
 ```
 
@@ -52,7 +55,7 @@ The example below demonstrates how to use a data directory for the "__COPY__" cl
 ```sql
 %%thanosql
 COPY mytable
-OPTIONS (overwrite=True)
+OPTIONS (if_exists='replace')
 FROM 'diet_image_data/'
 ```
 
@@ -69,7 +72,7 @@ df_in_json = df.to_json(orient="records")
 # use a f-string to wrap 'df_in_json' within the COPY clause 
 copy_pandas_df = f'''
 COPY mytable
-OPTIONS (overwrite=True)
+OPTIONS (if_exists='replace')
 FROM '{df_in_json}'
 '''
 ```

--- a/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -26,7 +26,10 @@ FROM {file_path | dir_path}
 
 !!! note "쿼리 세부 정보"
     - "__OPTIONS__" 절에서 매개변수의 값을 기본값으로부터 변경할 수 있습니다. 각 매개변수의 의미는 아래와 같습니다.
-        - "overwrite": 동일 이름의 테이블이 존재하는 경우 덮어쓰기 가능 여부를 설정합니다. True일 경우 기존 테이블은 새로운 테이블로 변경됩니다. (bool, optional, True|False, default: False)
+        - "if_exists": 동일 이름의 테이블이 존재하는 경우 처리하는 방법을 결정합니다. 오류를 발생시키거나, 기존 테이블에 추가하거나, 기존 테이블을 대체할 수 있습니다. (str, optional, 'fail'|'replace'|'append', default: 'fail')
+            - "fail": 기존 테이블이 이미 있는 경우 오류 발생
+            - "replace": 기존 테이블이 이미 있는 경우 테이블 대체 
+            - "append": 지정된 데이터프레임을 기존 테이블에 추가
         - "chunksize": 한 번에 쓸 각 배치의 행 수입니다. 기본적으로 모든 행이 한 번에 기록됩니다 (int, optional, default: 1000)
 
 ## __3. COPY 예시__
@@ -38,7 +41,7 @@ FROM {file_path | dir_path}
 ```sql
 %%thanosql
 COPY mytable
-OPTIONS (overwrite=True)
+OPTIONS (if_exists='replace')
 FROM 'data/example.csv'
 ```
 
@@ -52,7 +55,7 @@ FROM 'data/example.csv'
 ```sql
 %%thanosql
 COPY mytable
-OPTIONS (overwrite=True)
+OPTIONS (if_exists='replace')
 FROM 'diet_image_data/'
 ```
 
@@ -70,7 +73,7 @@ df_in_json = df.to_json(orient="records")
 # f-string을 사용하여 'df_in_json'을 COPY 구문으로 감싸줍니다
 copy_pandas_df = f'''
 COPY mytable
-OPTIONS (overwrite=True)
+OPTIONS (if_exists='replace')
 FROM '{df_in_json}'
 '''
 ```


### PR DESCRIPTION
# Description (개요) 

Related to: [ThanoSQL Engine PR #192](https://github.com/smartmind-team/thanosql-engine/pull/192) 
From the above PR, ThanoSQL COPY clause's 'overwrite' functionality has been replaced by the 'if_exists'. Therefore, this PR has been created to implement the changes. 

Also related to [ThanoSQL Tutorial PR #75](https://github.com/smartmind-team/thanosql-tutorial/pull/75)

## Keep in Mind

If you are creating a new statement, your first commit should always be a copy of the statement(model, ThanoSQL, function) template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

Please delete options that are not relevant and check out the type of change.

- [x] ThanoSQL statement fix 

Following templates can be found from the [Tech-wiki Docs](https://github.com/smartmind-team/tech-wiki/tree/main/project/thanosql/docs). 

## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.