### PR TITLE
update: chunksize deleted from COPY syntax

### DIFF
--- a/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -30,7 +30,6 @@ FROM {file_path | dir_path}
             - "fail": raise an error if there is already an existing table
             - "replace": replace a table if there is already an existing table
             - "append": append given dataframe to an existing table
-        - "chunksize": the number of rows in each batch to be written at a time. By default, all rows will be written at once (int, optonal, default: 1000)
 
 ## __3. COPY Example__
 

--- a/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -30,7 +30,6 @@ FROM {file_path | dir_path}
             - "fail": 기존 테이블이 이미 있는 경우 오류 발생
             - "replace": 기존 테이블이 이미 있는 경우 테이블 대체 
             - "append": 지정된 데이터프레임을 기존 테이블에 추가
-        - "chunksize": 한 번에 쓸 각 배치의 행 수입니다. 기본적으로 모든 행이 한 번에 기록됩니다 (int, optional, default: 1000)
 
 ## __3. COPY 예시__
 


### PR DESCRIPTION
# Description (개요) 

Related to [ThanoSQL Engine PR](https://github.com/smartmind-team/thanosql-engine/pull/197)
COPY clause's 'chunksize' deprecated. 

## Keep in Mind

If you are creating a new statement, your first commit should always be a copy of the statement(model, ThanoSQL, function) template. This will allow reviewers to see what has been changed from the template, making the review process much more efficient.

## Type of change (작업사항)

- [x] ThanoSQL statement fix 

Following templates can be found from the [Tech-wiki Docs](https://github.com/smartmind-team/tech-wiki/tree/main/project/thanosql/docs). 

## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.