### PR TITLE
Fix/v1.4 revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ThanoSQL Docs
 
-ThanoSQL Technical Documentation - https://docs.thanosql.ai
+ThanoSQL Technical Documentation - [https://docs.thanosql.ai](https://docs.thanosql.ai)
 
 The ThanoSQL documentation website provides comprehensive guidance on how to use ThanoSQL. The website is divided into several sections, including an introduction to ThanoSQL, a getting started guide, tutorials, a reference guide, and a frequently asked questions (FAQ) section.
 
-The `Intro` section provides a high-level overview of ThanoSQL, highlighting its features and capabilities. 
+The `Intro` section provides a high-level overview of ThanoSQL, highlighting its features and capabilities.
 
 The `Getting Started` guide offers step-by-step instructions on how to install and set up ThanoSQL, as well as tips on how to get started using the software.
 
@@ -17,6 +17,7 @@ The `FAQ` section offers answers to common questions about using ThanoSQL, troub
 ## Contributing
 
 We welcome contributions to the ThanoSQL documentation! To contribute, follow these steps:
+
 - Fork this repository.
 - Make your changes.
 - Submit a pull request.
@@ -50,6 +51,7 @@ mkdocs serve --dev-addr 192.168.x.x:8000
 ```
 
 ## Additional Information
+
 The documentation is powered by [MkDocs](https://www.mkdocs.org/), a fast and simple static site generator.
 
 If you are a member of smartmind, and want more information about mkdocs check [Clickup](https://app.clickup.com/31080411/v/dc/xmfyv-1363/xmfyv-8363)

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
@@ -48,17 +48,17 @@ Execute ThanoSQL queries and receive a query log as a response.
 
 
 ### __Parameters__
-    
+
 The API can set a destination table to save the results from a query using query parameters. If nothing is specified, then a destination table will be created in the qm schema.
 
 
 - `schema`: The schema to retrieve the tables from. If no parameter is provided, defaults to "qm".
-- `table_name`: The name that will be used to create the table. If not parameter is provided, defaults to a randomly generated table name 
+- `table_name`: The name that will be used to create the table. If not parameter is provided, defaults to a randomly generated table name.
 - `overwrite`: Determines if the table shall be overwritten or not. Defaults to False.
 
 ### __Response__
 
-The `/query` API returns a query log (shown below) as a response. 
+The `/query` API returns a query log (shown below) as a response.
 
 If the query statement yields results (statements such as SELECT, LIST), then the results are stored into a destination table. The destination table is specified by the `destination_table_name` and `destination_schema`. If the query produces no results, then the destination table indicates the table that was affected
 

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
@@ -94,11 +94,10 @@ This method retrieves a paginated list of all query logs.
 
     api_token = "Issued_API_TOKEN"
     base_url = "https://{your-engine-url}/api/v1/query/log"
-    search = "Search keyword(s)"
     offset = {Offset}
     limit = {Limit}
 
-    api_url = f"{base_url}?search={search}&offset={offset}&limit={limit}"
+    api_url = f"{base_url}?offset={offset}&limit={limit}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -113,13 +112,12 @@ This method retrieves a paginated list of all query logs.
 
     ```shell
       curl -X 'GET' \
-      'https://{your-engine-url}/api/v1/query/log/?search={search}&offset={offset}&limit={limit}' \
+      'https://{your-engine-url}/api/v1/query/log/?offset={offset}&limit={limit}' \
       -H 'accept: application/json' \
       -H 'Authorization: Bearer Issued_API_TOKEN'
     ```
 
 ### __Parameters__
 
-- `search`: Word(s) that the returned query logs should contain.
 - `offset`: The offset to where the pagination count will start from (defaults to 0).
 - `limit`: The maximum number of items to retrieve starting from the offset (defaults to 100, max 100).

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
@@ -95,8 +95,8 @@ This method retrieves a paginated list of all query logs.
     api_token = "Issued_API_TOKEN"
     base_url = "https://{your-engine-url}/api/v1/query/log"
     search = "Search keyword(s)"
-    offset = "Offset"
-    limit = "Limit"
+    offset = {Offset}
+    limit = {Limit}
 
     api_url = f"{base_url}?search={search}&offset={offset}&limit={limit}"
 

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
@@ -80,3 +80,46 @@ If the query statement yields results (statements such as SELECT, LIST), then th
 
 !!! warning "__Warning__"
     - Columns created using "__CONVERT__" are encoded using base64. To use it as a column containing bytes, it must be decoded using base64's b64decode.
+
+
+## **`GET` /query/log**
+
+This method retrieves a paginated list of all query logs.
+
+=== "Python"
+
+    ```python
+    import requests
+    import json
+
+    api_token = "Issued_API_TOKEN"
+    base_url = "https://{your-engine-url}/api/v1/query/log"
+    search = "Search keyword(s)"
+    offset = "Offset"
+    limit = "Limit"
+
+    api_url = f"{base_url}?search={search}&offset={offset}&limit={limit}"
+
+    header = {
+        "Authorization": f"Bearer {api_token}"
+    }
+
+    r = requests.get(api_url, headers=header):
+    r.raise_for_status()
+    r.json()
+    ```
+
+=== "cURL"
+
+    ```shell
+      curl -X 'GET' \
+      'https://{your-engine-url}/api/v1/query/log/?search={search}&offset={offset}&limit={limit}' \
+      -H 'accept: application/json' \
+      -H 'Authorization: Bearer Issued_API_TOKEN'
+    ```
+
+### __Parameters__
+
+- `search`: Word(s) that the returned query logs should contain.
+- `offset`: The offset to where the pagination count will start from (defaults to 0).
+- `limit`: The maximum number of items to retrieve starting from the offset (defaults to 100, max 100).

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
@@ -434,8 +434,8 @@ Retrieves the paginated records of a table in a schema.
     base_url = "https://{your-engine-url}/api/v1/table"
     table_name = "Table name"
     schema = "Target schema"
-    offset = "Offset"
-    limit = "Limit"
+    offset = {Offset}
+    limit = {Limit}
 
     api_url = f"{base_url}/{table_name}/records?schema={schema}&offset={offset}&limit={limit}"
 

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
@@ -33,7 +33,7 @@ You can use the ThanoSQL Table REST API for several CRUD operations on your Than
 
 ## **`GET` /table**
 
-In order to get a list of all of your tables, use the method below. If no `schema_name` is provided, then tables from every schemas will be listed.
+In order to get a list of all of your tables, use the method below. If no `schema` is provided, then tables from every schemas will be listed.
 
 === "Python"
 
@@ -43,9 +43,9 @@ In order to get a list of all of your tables, use the method below. If no `schem
 
     api_token = "Issued_API_TOKEN"
     base_url="https://{your-engine-url}/api/v1/table"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
-    api_url = f"{base_url}?schema_name={schema_name}"
+    api_url = f"{base_url}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -69,7 +69,7 @@ In order to get a list of all of your tables, use the method below. If no `schem
 
 ## **`GET` /table/{table_name}**
 
-Use this method to get the objects of a single table. If no `schema_name` query parameter is provided, the parameter defaults to the public schema.
+Use this method to get the objects of a single table. If no `schema` query parameter is provided, the parameter defaults to the public schema.
 
 === "Python"
 
@@ -80,9 +80,9 @@ Use this method to get the objects of a single table. If no `schema_name` query 
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table/"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -105,7 +105,7 @@ Use this method to get the objects of a single table. If no `schema_name` query 
   
 ## **`PUT` /table/{table_name}**
 
-The ALTER Table API is used to do several ALTER TABLE operations. In order to alter the table you simply alter the database object specified by the `table_name` and `schema_name`. To UPDATE something, simply change the value of the Table object. To DROP, just remove the object from the request body.
+The ALTER Table API is used to do several ALTER TABLE operations. In order to alter the table you simply alter the database object specified by the `table_name` and `schema`. To UPDATE something, simply change the value of the Table object. To DROP, just remove the object from the request body.
 
 !!! note "__Order Execution__"
     The order of execution of the ALTER is as follows:
@@ -168,7 +168,7 @@ In the following example lets pretend we want to alter the table object below:
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table/"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
     new_table = {
             "table": {
@@ -203,7 +203,7 @@ In the following example lets pretend we want to alter the table object below:
             }
         }
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -219,7 +219,7 @@ In the following example lets pretend we want to alter the table object below:
 
     ```shell
       curl -X 'PUT' \
-    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema_name}' \
+    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema}' \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -255,12 +255,12 @@ In the following example lets pretend we want to alter the table object below:
         }
     }'
     ```
-  If no `schema_name` query parameter is provided, the parameter defaults to the public schema.
+  If no `schema` query parameter is provided, the parameter defaults to the public schema.
 
 
 ## **`POST` /table/{table_name}**
 
-Use this method to execute the CREATE TABLE operation. In order to create the table you simply pass in a database object as a body with the `table_name` and `schema_name` as query params.
+Use this method to execute the CREATE TABLE operation. In order to create the table you simply pass in a database object as a body with the `table_name` and `schema` as query params.
 
 !!! note " "
     When adding Column objects to the list of columns, there is no need to specify the id since the id just refers to the ordinal position of the column. Additionally if the table is created with an empty body, an empty table will be created. If no table_name is specified, the table will be created with a random uuid string.
@@ -275,7 +275,7 @@ Use this method to execute the CREATE TABLE operation. In order to create the ta
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table/"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
     # Note that the name and schema keys are missing from the body
     new_table = {
@@ -320,7 +320,7 @@ Use this method to execute the CREATE TABLE operation. In order to create the ta
             }
         }
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -336,7 +336,7 @@ Use this method to execute the CREATE TABLE operation. In order to create the ta
 
     ```shell
       curl -X 'POST' \
-    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema_name}' \
+    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema}' \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -384,7 +384,7 @@ Use this method to execute the CREATE TABLE operation. In order to create the ta
 
 ## **`DELETE` /table/{table_name}**
 
-To delete a table, use the method below. If no `schema_name` query parameter is provided, the parameter defaults to the public schema.
+To delete a table, use the method below. If no `schema` query parameter is provided, the parameter defaults to the public schema.
 
 
 === "Python"
@@ -396,9 +396,9 @@ To delete a table, use the method below. If no `schema_name` query parameter is 
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -415,6 +415,88 @@ To delete a table, use the method below. If no `schema_name` query parameter is 
     ```shell
       curl -X 'DELETE' \
       'https://{your-engine-url}/api/v1/table/{table_name}?schema=public' \
+      -H 'accept: application/json' \
+      -H 'Authorization: Bearer Issued_API_TOKEN'
+    ```
+
+
+## **`GET` /table/{table_name}/records**
+
+Retrieves the paginated records of a table in a schema.
+
+=== "Python"
+
+    ```python
+    import requests
+    import json
+
+    api_token = "Issued_API_TOKEN"
+    base_url = "https://{your-engine-url}/api/v1/table"
+    table_name = "Table name"
+    schema = "Target schema"
+    offset = "Offset"
+    limit = "Limit"
+
+    api_url = f"{base_url}/{table_name}/records?schema={schema}&offset={offset}&limit={limit}"
+
+    header = {
+        "Authorization": f"Bearer {api_token}"
+    }
+
+    r = requests.get(api_url, headers=header):
+    r.raise_for_status()
+    r.json()
+    ```
+
+=== "cURL"
+
+    ```shell
+      curl -X 'GET' \
+      'https://{your-engine-url}/api/v1/table/{table_name}/records?schema={schema}&offset={offset}&limit={limit}' \
+      -H 'accept: application/json' \
+      -H 'Authorization: Bearer Issued_API_TOKEN'
+    ```
+
+
+### __Parameters__
+
+- `table_name`: The table name to retrieve the records from.
+- `schema`: The schema to search the table in (defaults to 'public').
+- `offset`: The offset to where the pagination count will start from (defaults to 0).
+- `limit`: The maximum number of records to retrieve starting from the offset (defaults to 100, max 100).
+
+
+## **`GET` /table/{table_name}/records/csv**
+
+Retrieves the records of a table in a schema as a CSV file.
+
+=== "Python"
+
+    ```python
+    import requests
+    import json
+
+    api_token = "Issued_API_TOKEN"
+    base_url = "https://{your-engine-url}/api/v1/table"
+    table_name = "Table name"
+    timezone_offset = "Timezone offset from GMT (default: 9 (GMT+9, Seoul time))"
+
+    api_url = f"{base_url}/{table_name}/records/csv?schema={schema}&timezone_offset={timezone_offset}"
+
+    header = {
+        "Authorization": f"Bearer {api_token}"
+    }
+
+    r = requests.get(api_url, headers=header):
+    r.raise_for_status()
+    r.json()
+    ```
+
+=== "cURL"
+
+    ```shell
+      curl -X 'GET' \
+      'https://{your-engine-url}/api/v1/table/{table_name}/records/csv?schema={schema}&timezone_offset={timezone_offset}' \
       -H 'accept: application/json' \
       -H 'Authorization: Bearer Issued_API_TOKEN'
     ```

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
@@ -33,7 +33,7 @@ You can use the ThanoSQL Table REST API for several CRUD operations on your Than
 
 ## **`GET` /table**
 
-In order to get a list of all of your tables, use the method below. If no `schema_name` is provided, then tables from every schemas will be listed. 
+In order to get a list of all of your tables, use the method below. If no `schema_name` is provided, then tables from every schemas will be listed.
 
 === "Python"
 
@@ -69,7 +69,7 @@ In order to get a list of all of your tables, use the method below. If no `schem
 
 ## **`GET` /table/{table_name}**
 
-Use this method to get the objects of a single table. If no `schema_name` query parameter is provided, the parameter defaults to the public schema. 
+Use this method to get the objects of a single table. If no `schema_name` query parameter is provided, the parameter defaults to the public schema.
 
 === "Python"
 
@@ -105,7 +105,7 @@ Use this method to get the objects of a single table. If no `schema_name` query 
   
 ## **`PUT` /table/{table_name}**
 
-The ALTER Table API is used to do several ALTER TABLE operations. In order to alter the table you simply alter the database object specified by the `table_name` and `schema_name`. To UPDATE something, simply change the value of the Table object. To DROP, just remove the object from the request body. 
+The ALTER Table API is used to do several ALTER TABLE operations. In order to alter the table you simply alter the database object specified by the `table_name` and `schema_name`. To UPDATE something, simply change the value of the Table object. To DROP, just remove the object from the request body.
 
 !!! note "__Order Execution__"
     The order of execution of the ALTER is as follows:
@@ -114,9 +114,10 @@ The ALTER Table API is used to do several ALTER TABLE operations. In order to al
 
 
 !!! warning ""
-    When dealing with columns, it is important to note that the id is the unique key that is used to identify the column. If this value is deleted, that means that the column will also be deleted. If you are making a change to the column, **make sure that the column id is present in the body**! When adding a new column, a column_id is not required as it will be assigned after the column is created. 
+    When dealing with columns, it is important to note that the id is the unique key that is used to identify the column. If this value is deleted, that means that the column will also be deleted. If you are making a change to the column, **make sure that the column id is present in the body**! When adding a new column, a column_id is not required as it will be assigned after the column is created.
 
 In the following example lets pretend we want to alter the table object below:
+
 ```json
 {
     "table": {
@@ -254,12 +255,12 @@ In the following example lets pretend we want to alter the table object below:
         }
     }'
     ```
-  If no `schema_name` query parameter is provided, the parameter defaults to the public schema. 
+  If no `schema_name` query parameter is provided, the parameter defaults to the public schema.
 
 
 ## **`POST` /table/{table_name}**
 
-Use this method to execute the CREATE TABLE operation. In order to create the table you simply pass in a database object as a body with the `table_name` and `schema_name` as query params. 
+Use this method to execute the CREATE TABLE operation. In order to create the table you simply pass in a database object as a body with the `table_name` and `schema_name` as query params.
 
 !!! note " "
     When adding Column objects to the list of columns, there is no need to specify the id since the id just refers to the ordinal position of the column. Additionally if the table is created with an empty body, an empty table will be created. If no table_name is specified, the table will be created with a random uuid string.
@@ -383,7 +384,7 @@ Use this method to execute the CREATE TABLE operation. In order to create the ta
 
 ## **`DELETE` /table/{table_name}**
 
-To delete a table, use the method below. If no `schema_name` query parameter is provided, the parameter defaults to the public schema. 
+To delete a table, use the method below. If no `schema_name` query parameter is provided, the parameter defaults to the public schema.
 
 
 === "Python"

--- a/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
+++ b/docs/en/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
@@ -7,7 +7,7 @@ title: Table APIs
 You can use the ThanoSQL Table REST API for several CRUD operations on your ThanoSQL DB tables.
 
 !!! Note "__Table Object__"
-    A table object consists of four main componenets:
+    A table object consists of four main components:
 
     1. *`name`: The name of the table
     2. *`schema`: The schema that the table is a part of

--- a/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
+++ b/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
@@ -77,3 +77,45 @@ ThanoSQL 쿼리를 실행하고 쿼리 로그를 응답으로 받습니다.
 !!! warning "__Warning__"
     - "__CONVERT__"를 사용해 만들어진 컬럼의 값들은 base64로 인코딩됩니다. 바이트 형식의 값을 사용하려면 base64의 b64decode를 사용하여 디코딩해야 합니다.
 
+
+## **`GET` /query/log**
+
+이 메서드는 모든 쿼리 로그의 paginated 목록을 검색합니다.
+
+=== "Python"
+
+    ```python
+    import requests
+    import json
+
+    api_token = "Issued_API_TOKEN"
+    base_url = "https://{your-engine-url}/api/v1/query/log"
+    search = "Search keyword(s)"
+    offset = "Offset"
+    limit = "Limit"
+
+    api_url = f"{base_url}?search={search}&offset={offset}&limit={limit}"
+
+    header = {
+        "Authorization": f"Bearer {api_token}"
+    }
+
+    r = requests.get(api_url, headers=header):
+    r.raise_for_status()
+    r.json()
+    ```
+
+=== "cURL"
+
+    ```shell
+      curl -X 'GET' \
+      'https://{your-engine-url}/api/v1/query/log/?search={search}&offset={offset}&limit={limit}' \
+      -H 'accept: application/json' \
+      -H 'Authorization: Bearer Issued_API_TOKEN'
+    ```
+
+### __Parameters__
+
+- `search`: 반환된 쿼리 로그에 포함되어야 하는 단어입니다.
+- `offset`: pagination count이 시작되는 오프셋입니다(기본값은 0).
+- `limit`: 오프셋에서 시작하여 검색할 최대 항목 수입니다(기본값은 100, 최대 100).

--- a/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
+++ b/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
@@ -90,11 +90,10 @@ ThanoSQL 쿼리를 실행하고 쿼리 로그를 응답으로 받습니다.
 
     api_token = "Issued_API_TOKEN"
     base_url = "https://{your-engine-url}/api/v1/query/log"
-    search = "Search keyword(s)"
     offset = {Offset}
     limit = {Limit}
 
-    api_url = f"{base_url}?search={search}&offset={offset}&limit={limit}"
+    api_url = f"{base_url}?offset={offset}&limit={limit}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -109,13 +108,12 @@ ThanoSQL 쿼리를 실행하고 쿼리 로그를 응답으로 받습니다.
 
     ```shell
       curl -X 'GET' \
-      'https://{your-engine-url}/api/v1/query/log/?search={search}&offset={offset}&limit={limit}' \
+      'https://{your-engine-url}/api/v1/query/log/?offset={offset}&limit={limit}' \
       -H 'accept: application/json' \
       -H 'Authorization: Bearer Issued_API_TOKEN'
     ```
 
 ### __Parameters__
 
-- `search`: 반환된 쿼리 로그에 포함되어야 하는 단어입니다.
 - `offset`: pagination count이 시작되는 오프셋입니다(기본값은 0).
 - `limit`: 오프셋에서 시작하여 검색할 최대 항목 수입니다(기본값은 100, 최대 100).

--- a/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
+++ b/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_query.md
@@ -91,8 +91,8 @@ ThanoSQL 쿼리를 실행하고 쿼리 로그를 응답으로 받습니다.
     api_token = "Issued_API_TOKEN"
     base_url = "https://{your-engine-url}/api/v1/query/log"
     search = "Search keyword(s)"
-    offset = "Offset"
-    limit = "Limit"
+    offset = {Offset}
+    limit = {Limit}
 
     api_url = f"{base_url}?search={search}&offset={offset}&limit={limit}"
 

--- a/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
+++ b/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
@@ -33,7 +33,7 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
 
 ## **`GET` /table**
 
-모든 테이블의 목록을 가져오려면 아래 메서드를 사용합니다. `schema_name`을 제공하지 않으면 모든 스키마의 테이블이 표시됩니다.
+모든 테이블의 목록을 가져오려면 아래 메서드를 사용합니다. `schema`을 제공하지 않으면 모든 스키마의 테이블이 표시됩니다.
 
 === "Python"
 
@@ -43,9 +43,9 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
 
     api_token = "Issued_API_TOKEN"
     base_url="https://{your-engine-url}/api/v1/table"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
-    api_url = f"{base_url}?schema_name={schema_name}"
+    api_url = f"{base_url}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -69,7 +69,7 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
 
 ## **`GET` /table/{table_name}**
 
-단일 테이블의 개체를 가져오려면 이 메서드를 사용합니다. `schema_name` 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
+단일 테이블의 개체를 가져오려면 이 메서드를 사용합니다. `schema` 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
 
 === "Python"
 
@@ -80,9 +80,9 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table/"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -105,7 +105,7 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
   
 ## **`PUT` /table/{table_name}**
 
-ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용됩니다. 테이블을 변경하려면 `table_name` 및 `schema_name`으로 지정된 데이터베이스 객체를 변경하기만 하면 됩니다. UPDATE하려면 테이블 객체의 값을 변경하기만 하면 됩니다. DROP하려면 요청 본문에서 해당 개체를 제거하면 됩니다.
+ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용됩니다. 테이블을 변경하려면 `table_name` 및 `schema`으로 지정된 데이터베이스 객체를 변경하기만 하면 됩니다. UPDATE하려면 테이블 객체의 값을 변경하기만 하면 됩니다. DROP하려면 요청 본문에서 해당 개체를 제거하면 됩니다.
 
 !!! note "__Order Execution__"
     ALTER의 실행 순서는 다음과 같습니다:
@@ -167,7 +167,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table/"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
     new_table = {
             "table": {
@@ -202,7 +202,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
             }
         }
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -218,7 +218,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
 
     ```shell
       curl -X 'PUT' \
-    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema_name}' \
+    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema}' \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -254,12 +254,12 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
         }
     }'
     ```
-  `schema_name` 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
+  `schema` 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
 
 
 ## **`POST` /table/{table_name}**
 
-이 메서드를 사용하여 CREATE TABLE 작업을 실행합니다. 테이블을 생성하려면 데이터베이스 객체를 본문으로 전달하고 쿼리 매개변수로 `table_name` 및 `schema_name`을 전달하기만 하면 됩니다.
+이 메서드를 사용하여 CREATE TABLE 작업을 실행합니다. 테이블을 생성하려면 데이터베이스 객체를 본문으로 전달하고 쿼리 매개변수로 `table_name` 및 `schema`을 전달하기만 하면 됩니다.
 
 !!! note " "
     열 개체를 열 목록에 추가할 때 id는 열의 서수 위치만 참조하므로 id를 지정할 필요가 없습니다. 또한 테이블이 빈 본문으로 생성되는 경우 빈 테이블이 생성됩니다. `table_name`을 지정하지 않으면 임의의 uuid 문자열로 테이블이 생성됩니다.
@@ -274,7 +274,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table/"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
     # 본문에서 이름 및 스키마 키가 누락되었습니다.
     new_table = {
@@ -319,7 +319,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
             }
         }
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"
@@ -335,7 +335,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
 
     ```shell
       curl -X 'POST' \
-    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema_name}' \
+    'https://{your-engine-url}/api/v1/table/{table_name}?schema={schema}' \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -383,7 +383,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
 
 ## **`DELETE` /table/{table_name}**
 
-테이블을 삭제하려면 아래 메서드를 사용합니다. `schema_name` 쿼리 매개변수가 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
+테이블을 삭제하려면 아래 메서드를 사용합니다. `schema` 쿼리 매개변수가 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
 
 
 === "Python"
@@ -395,9 +395,9 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
     api_token = "Issued_API_TOKEN"
     table_name = "Table Name"
     base_url="https://{your-engine-url}/api/v1/table"
-    schema_name = "Schema Name"
+    schema = "Schema Name"
 
-    api_url = f"{base_url}/{table_name}?schema_name={schema_name}"
+    api_url = f"{base_url}/{table_name}?schema={schema}"
 
     header = {
         "Authorization": f"Bearer {api_token}"

--- a/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
+++ b/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
@@ -4,36 +4,36 @@ title: Table APIs
 
 # **Table APIs**
 
-You can use the ThanoSQL Table REST API for several CRUD operations on your ThanoSQL DB tables.
+ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여러 CRUD 작업을 수행할 수 있습니다.
 
 !!! Note "__Table Object__"
-    A table object consists of four main componenets:
+    테이블 객체는 네 가지 주요 구성 요소로 구성됩니다:
 
-    1. *`name`: The name of the table
-    2. *`schema`: The schema that the table is a part of
+    1. *`name`: 테이블의 이름
+    2. *`schema`: 테이블이 속한 스키마
     3. `columns`
-        - `id`: The ordinal position of the column
-        - `default`: The default value of the column
-        - `is_nullable`: A boolean determining if the column is nullable
-        - `type`: [Data type](https://www.postgresql.org/docs/current/datatype.html#:~:text=Table%C2%A08.1.%C2%A0Data%20Types) of the column
-        - `name`: The name of the column
+        - `id`: 열의 서수 위치
+        - `default`: 열의 기본값
+        - `is_nullable`: 열이 널화 가능한지 여부를 나타내는 부울
+        - `type`: 열의 [데이터 타입](https://www.postgresql.org/docs/current/datatype.html#:~:text=Table%C2%A08.1.%C2%A0Data%20Types)
+        - `name`: 열의 이름
     4. `constraints`
-        - `primary_key`: The primary key of the table 
-            - `name`: The constraint name of the primary key
-            - `columns`: The columns that make up the primary key
+        - `primary_key`: 테이블의 기본 키
+            - `name`: 기본 키의 제약 조건 이름
+            - `columns`: 기본 키를 구성하는 열
         - `foreign_keys`: 
-            - `name`: The constraint name of the foreign key
-            - `reference_schema`: The schema that contains the `reference_table`
-            - `reference_table`: The table that contains the `reference_column`
-            - `reference_column`: The column that the foreign key is referring to
-            - `column`: The foreign key column
+            - `name`: 외래 키의 제약 조건 이름
+            - `reference_schema`: `reference_table` 포함하는 스키마
+            - `reference_table`: `reference_column` 포함하는 테이블
+            - `reference_column`: 외래 키가 참조하는 열
+            - `column`: 외래 키 열
 
-    _The above components that have a * next to its name will not be included in the body for the POST table API. Instead, it will be specified in the URL as query parameters._
+    _이름 옆에 *가 붙은 위의 구성 요소는 POST 테이블 API의 본문에 포함되지 않습니다. 대신 URL에 쿼리 매개변수로 지정됩니다._
 
 
 ## **`GET` /table**
 
-In order to get a list of all of your tables, use the method below. If no `schema_name` is provided, then tables from every schemas will be listed. 
+모든 테이블의 목록을 가져오려면 아래 메서드를 사용합니다. `schema_name`을 제공하지 않으면 모든 스키마의 테이블이 표시됩니다.
 
 === "Python"
 
@@ -69,7 +69,7 @@ In order to get a list of all of your tables, use the method below. If no `schem
 
 ## **`GET` /table/{table_name}**
 
-Use this method to get the objects of a single table. If no `schema_name` query parameter is provided, the parameter defaults to the public schema. 
+단일 테이블의 개체를 가져오려면 이 메서드를 사용합니다. `schema_name` 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
 
 === "Python"
 
@@ -105,18 +105,18 @@ Use this method to get the objects of a single table. If no `schema_name` query 
   
 ## **`PUT` /table/{table_name}**
 
-The ALTER Table API is used to do several ALTER TABLE operations. In order to alter the table you simply alter the database object specified by the `table_name` and `schema_name`. To UPDATE something, simply change the value of the Table object. To DROP, just remove the object from the request body. 
+ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용됩니다. 테이블을 변경하려면 `table_name` 및 `schema_name`으로 지정된 데이터베이스 객체를 변경하기만 하면 됩니다. UPDATE하려면 테이블 객체의 값을 변경하기만 하면 됩니다. DROP하려면 요청 본문에서 해당 개체를 제거하면 됩니다.
 
 !!! note "__Order Execution__"
-    The order of execution of the ALTER is as follows:
+    ALTER의 실행 순서는 다음과 같습니다:
 
     DROP PRIMARY KEY -> DROP FOREIGN KEY -> DROP COLUMN -> ADD COLUMN -> ALTER COLUMN -> RENAME COLUMN -> ADD PRIMARY KEY -> ADD FOREIGN KEY -> RENAME TABLE -> SET SCHEMA
 
 
 !!! warning ""
-    When dealing with columns, it is important to note that the id is the unique key that is used to identify the column. If this value is deleted, that means that the column will also be deleted. If you are making a change to the column, **make sure that the column id is present in the body**! When adding a new column, a column_id is not required as it will be assigned after the column is created. 
+    열을 다룰 때 id는 열을 식별하는 데 사용되는 고유 키라는 점에 유의하는 것이 중요합니다. 이 값이 삭제되면 열도 삭제된다는 의미입니다. 열을 변경하는 경우 **열 ID가 본문에 있는지 확인하세요**! 새 컬럼을 추가할 때는 컬럼이 생성된 후 할당되므로 column_id는 필요하지 않습니다.
 
-In the following example lets pretend we want to alter the table object below:
+다음 예제에서는 아래의 테이블 객체를 변경한다고 가정해 보겠습니다:
 ```json
 {
     "table": {
@@ -254,15 +254,15 @@ In the following example lets pretend we want to alter the table object below:
         }
     }'
     ```
-  If no `schema_name` query parameter is provided, the parameter defaults to the public schema. 
+  `schema_name` 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
 
 
 ## **`POST` /table/{table_name}**
 
-Use this method to execute the CREATE TABLE operation. In order to create the table you simply pass in a database object as a body with the `table_name` and `schema_name` as query params. 
+이 메서드를 사용하여 CREATE TABLE 작업을 실행합니다. 테이블을 생성하려면 데이터베이스 객체를 본문으로 전달하고 쿼리 매개변수로 `table_name` 및 `schema_name`을 전달하기만 하면 됩니다.
 
 !!! note " "
-    When adding Column objects to the list of columns, there is no need to specify the id since the id just refers to the ordinal position of the column. Additionally if the table is created with an empty body, an empty table will be created. If no table_name is specified, the table will be created with a random uuid string.
+    열 개체를 열 목록에 추가할 때 id는 열의 서수 위치만 참조하므로 id를 지정할 필요가 없습니다. 또한 테이블이 빈 본문으로 생성되는 경우 빈 테이블이 생성됩니다. `table_name`을 지정하지 않으면 임의의 uuid 문자열로 테이블이 생성됩니다.
 
 
 === "Python"
@@ -276,7 +276,7 @@ Use this method to execute the CREATE TABLE operation. In order to create the ta
     base_url="https://{your-engine-url}/api/v1/table/"
     schema_name = "Schema Name"
 
-    # Note that the name and schema keys are missing from the body
+    # 본문에서 이름 및 스키마 키가 누락되었습니다.
     new_table = {
             "table": {
                 "columns": [
@@ -383,7 +383,7 @@ Use this method to execute the CREATE TABLE operation. In order to create the ta
 
 ## **`DELETE` /table/{table_name}**
 
-To delete a table, use the method below. If no `schema_name` query parameter is provided, the parameter defaults to the public schema. 
+테이블을 삭제하려면 아래 메서드를 사용합니다. `schema_name` 쿼리 매개변수가 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
 
 
 === "Python"

--- a/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
+++ b/docs/ko/how-to_guides/ThanoSQL_connecting/rest_api_thanosql_tables.md
@@ -4,7 +4,7 @@ title: Table APIs
 
 # **Table APIs**
 
-ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여러 CRUD 작업을 수행할 수 있습니다.
+Table APIs로 ThanoSQL 워크스페이스 데이터베이스 테이블에 여러 CRUD 작업을 수행할 수 있습니다.
 
 !!! Note "__Table Object__"
     테이블 객체는 네 가지 주요 구성 요소로 구성됩니다:
@@ -12,28 +12,28 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
     1. *`name`: 테이블의 이름
     2. *`schema`: 테이블이 속한 스키마
     3. `columns`
-        - `id`: 열의 서수 위치
-        - `default`: 열의 기본값
-        - `is_nullable`: 열이 널화 가능한지 여부를 나타내는 부울
-        - `type`: 열의 [데이터 타입](https://www.postgresql.org/docs/current/datatype.html#:~:text=Table%C2%A08.1.%C2%A0Data%20Types)
-        - `name`: 열의 이름
+        - `id`: 컬럼의 서수 위치
+        - `default`: 컬럼의 기본값
+        - `is_nullable`: 해당 컬럼이 널(null)을 허용하는지 여부를 나타내는 부울(boolean)
+        - `type`: 컬럼의 [데이터 타입](https://www.postgresql.org/docs/current/datatype.html#:~:text=Table%C2%A08.1.%C2%A0Data%20Types)
+        - `name`: 컬럼의 이름
     4. `constraints`
-        - `primary_key`: 테이블의 기본 키
-            - `name`: 기본 키의 제약 조건 이름
-            - `columns`: 기본 키를 구성하는 열
+        - `primary_key`: 테이블의 기본키
+            - `name`: 기본키의 제약 조건 이름
+            - `columns`: 기본 키를 구성하는 컬럼
         - `foreign_keys`: 
-            - `name`: 외래 키의 제약 조건 이름
+            - `name`: 외래키의 제약 조건 이름
             - `reference_schema`: `reference_table` 포함하는 스키마
             - `reference_table`: `reference_column` 포함하는 테이블
-            - `reference_column`: 외래 키가 참조하는 열
-            - `column`: 외래 키 열
+            - `reference_column`: 외래키가 참조하는 컬럼
+            - `column`: 외래키 컬럼
 
-    _이름 옆에 *가 붙은 위의 구성 요소는 POST 테이블 API의 본문에 포함되지 않습니다. 대신 URL에 쿼리 매개변수로 지정됩니다._
+    _이름 옆에 *가 붙은 위의 구성 요소는 `POST` Table API의 본문(Body)에 포함되지 않습니다. 대신 URL에 쿼리 매개변수로 지정됩니다._
 
 
 ## **`GET` /table**
 
-모든 테이블의 목록을 가져오려면 아래 메서드를 사용합니다. `schema`을 제공하지 않으면 모든 스키마의 테이블이 표시됩니다.
+모든 테이블의 목록을 가져오려면 아래 메서드를 사용합니다. `schema`를 지정하지 않으면 모든 스키마의 테이블이 표시됩니다.
 
 === "Python"
 
@@ -69,7 +69,7 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
 
 ## **`GET` /table/{table_name}**
 
-단일 테이블의 개체를 가져오려면 이 메서드를 사용합니다. `schema` 제공되지 않으면 기본적으로 public 스키마로 설정됩니다.
+단일 테이블 객체를 가져오려면 이 메서드를 사용합니다. `schema`의 기본 값은 public 입니다.
 
 === "Python"
 
@@ -105,7 +105,7 @@ ThanoSQL 테이블 REST API를 사용하여 ThanoSQL DB 테이블에 대한 여�
   
 ## **`PUT` /table/{table_name}**
 
-ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용됩니다. 테이블을 변경하려면 `table_name` 및 `schema`으로 지정된 데이터베이스 객체를 변경하기만 하면 됩니다. UPDATE하려면 테이블 객체의 값을 변경하기만 하면 됩니다. DROP하려면 요청 본문에서 해당 개체를 제거하면 됩니다.
+ALTER Table API는 여러 ALTER TABLE 작업을 수행하는 데 사용됩니다. 테이블을 변경하려면 `table_name` 및 `schema`로 지정된 '테이블 객체'를 변경합니다. UPDATE하려면 테이블 객체의 값을 수정하고, DROP하려면 요청 본문에서 해당 개체를 제거하면 됩니다.
 
 !!! note "__Order Execution__"
     ALTER의 실행 순서는 다음과 같습니다:
@@ -114,7 +114,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
 
 
 !!! warning ""
-    열을 다룰 때 id는 열을 식별하는 데 사용되는 고유 키라는 점에 유의하는 것이 중요합니다. 이 값이 삭제되면 열도 삭제된다는 의미입니다. 열을 변경하는 경우 **열 ID가 본문에 있는지 확인하세요**! 새 컬럼을 추가할 때는 컬럼이 생성된 후 할당되므로 column_id는 필요하지 않습니다.
+    컬럼을 다룰 때 `id`는 열을 식별하는 데 사용되는 고유 키라는 점에 유의하는 것이 중요합니다. 이 값이 삭제되면 열도 삭제된다는 의미입니다. 열을 변경하는 경우 **컬럼 `id`가 본문에 있는지 확인하세요**! 새 컬럼을 추가할 때는 컬럼이 생성된 후 할당되므로 컬럼 id는 필요하지 않습니다.
 
 다음 예제에서는 아래의 테이블 객체를 변경한다고 가정해 보겠습니다:
 ```json
@@ -259,10 +259,10 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
 
 ## **`POST` /table/{table_name}**
 
-이 메서드를 사용하여 CREATE TABLE 작업을 실행합니다. 테이블을 생성하려면 데이터베이스 객체를 본문으로 전달하고 쿼리 매개변수로 `table_name` 및 `schema`을 전달하기만 하면 됩니다.
+이 메서드를 사용하여 CREATE TABLE 작업을 실행합니다. 테이블을 생성하려면 테이블 객체를 본문으로 전달하고 쿼리 매개변수로 `table_name` 및 `schema`을 전달합니다.
 
 !!! note " "
-    열 개체를 열 목록에 추가할 때 id는 열의 서수 위치만 참조하므로 id를 지정할 필요가 없습니다. 또한 테이블이 빈 본문으로 생성되는 경우 빈 테이블이 생성됩니다. `table_name`을 지정하지 않으면 임의의 uuid 문자열로 테이블이 생성됩니다.
+    컬럼 객체를 열 목록에 추가할 때 id는 열의 서수 위치만 참조하므로, id를 지정할 필요가 없습니다. 또한 비어있는 본문(Body)은 빈 테이블이 생성됩니다. `table_name`을 지정하지 않으면 임의의 uuid 문자열을 이름으로 하는 테이블이 생성됩니다.
 
 
 === "Python"
@@ -276,7 +276,7 @@ ALTER 테이블 API는 여러 ALTER 테이블 작업을 수행하는 데 사용�
     base_url="https://{your-engine-url}/api/v1/table/"
     schema = "Schema Name"
 
-    # 본문에서 이름 및 스키마 키가 누락되었습니다.
+    # 본문(Body)에서 이름 및 스키마가 누락되었습니다.
     new_table = {
             "table": {
                 "columns": [


### PR DESCRIPTION
# Description (개요) 

- Add missing endpoint docs in engine version 1.4
- Translate tables docs from english to korean for ko version
- Fix incorrect parameter name in tables docs (schema_name -> schema)

## Type of change (작업사항)

Please delete options that are not relevant and check out the type of change.

- [x] Tables and query API docs fix 

## Writing Convention

Make sure to check out the [Writing Convention](https://github.com/smartmind-team/tech-wiki/blob/main/project/thanosql/docs/writing_convention.md). 

## Review Process

Review should be conducted by at least two people.