### PR TITLE
hotfix: COPY warning

### DIFF
--- a/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/en/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -14,6 +14,9 @@ The "__COPY__" statement allows users to create data tables in the ThanoSQL work
     - xls, xlsx, xlsm, xlsb
     - pqt, parquet 
 
+!!! warning "__Warning__"
+    - The PostgreSQL __COPY__ clause is not supported.
+
 ## __2. COPY Syntax__
 
 ```sql

--- a/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
+++ b/docs/ko/how-to_guides/ThanoSQL_query/COPY_SYNTAX.md
@@ -14,6 +14,9 @@ title: COPY
     - xls, xlsx, xlsm, xlsb
     - pqt, parquet 
 
+!!! warning "__Warning__"
+    - 기존 PostgreSQL 쿼리 __COPY__ 구문은 지원하지 않습니다.
+
 ## __2. COPY 구문__
 
 ```sql


### PR DESCRIPTION
# Description (개요) 

Adding COPY warning to notify users that the native PostgreSQL COPY clause is not supported by ThanoSQL